### PR TITLE
Replace : with _ in command names

### DIFF
--- a/Exporter/AnnotationSupervisorExporter.php
+++ b/Exporter/AnnotationSupervisorExporter.php
@@ -91,9 +91,7 @@ class AnnotationSupervisorExporter
 
     private function buildProgramName($commandName, $instance)
     {
-        $pos = strrpos($commandName, ':');
-
-        $name = (false === $pos) ? $commandName : substr($commandName, $pos + 1);
+        $name = str_replace(':', '_', $commandName);
 
         return (1 === $instance) ? $name : "{$name}_{$instance}";
     }

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -37,25 +37,25 @@ class DumpCommandTest extends SupervisorTestCase
         ]);
 
         $expected = <<<OUTPUT
-[program:test-command]
+[program:supervisor_test-command]
 autostart=true
 user=mybuilder
-name=test-command
+name=supervisor_test-command
 command=php app/console supervisor:test-command --env=test
 numprocs=1
 
-[program:test-command_2]
+[program:supervisor_test-command_2]
 process_name=%(program_name)s_%(process_num)02d
 autostart=true
 user=mybuilder
-name=test-command_2
+name=supervisor_test-command_2
 command=php app/console supervisor:test-command --env=test
 numprocs=2
 
-[program:test-command_3]
+[program:supervisor_test-command_3]
 autostart=true
 user=mybuilder
-name=test-command_3
+name=supervisor_test-command_3
 command=php -d mbstring.func_overload=0 app/console supervisor:test-command --foo --env=test
 numprocs=1
 OUTPUT;


### PR DESCRIPTION
Instead of using everything after the last : for the program name, replace all occurrences of : with valid _ character.
