### PR TITLE
Ensure command loaded within Symfony 4

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -6,3 +6,8 @@ services:
         arguments:
             - "@annotation_reader"
             - "%mybuilder.supervisor_bundle.exporter_config%"
+
+    # Ensure command is loaded within Symfony 4
+    MyBuilder\Bundle\SupervisorBundle\Command\DumpCommand:
+        tags:
+            - { name: 'console.command' }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "francodacosta/supervisord": "~1.0",
     "doctrine/annotations": "~1.0",
     "symfony/console": "~2.7 || ~3.0 || ~4.0",
+    "symfony/config": "~2.7 || ~3.0 || ~4.0",
     "symfony/framework-bundle": "~2.7 || ~3.0 || ~4.0",
     "php": "~7.0"
   },


### PR DESCRIPTION
It seems that the command is not auto-registered when including the bundle within a Symfony 4 app. Tagging the command as such ensure that it is present.