### PR TITLE
Add Symfony 4 support, fix Symfony 3/4 deprecation notices and drop support for Symfony 2 (and PHP < 7.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,32 @@
 language: php
 
-php:
-  - 7.0
-  - 7.3
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+    - .phpunit
 
 env:
-  - SYMFONY_VERSION=2.7.*
-  - SYMFONY_VERSION=3.0.*
-  - SYMFONY_VERSION=3.4.*
-  - SYMFONY_VERSION=4.0.*
-  - SYMFONY_VERSION=4.2.*
+  global:
+    - SYMFONY_PHPUNIT_DIR=.phpunit
 
-before_script:
-  - composer update symfony/console:${SYMFONY_VERSION}
-  - composer update symfony/framework-bundle:${SYMFONY_VERSION}
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.3
+      env: SYMFONY_VERSION="3.4.*"
+    - php: 7.3
+      env: SYMFONY_VERSION="4.4.*"
+    - php: 7.4
+      env: SYMFONY_VERSION="3.4.*"
+    - php: 7.4
+      env: SYMFONY_VERSION="4.4.*"
 
-script: bin/phpunit
+before_install:
+  - composer self-update
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/framework-bundle:"${SYMFONY_VERSION}"; fi
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/console:"${SYMFONY_VERSION}"; fi
+
+install:
+  - composer update $COMPOSER_FLAGS
+
+script: bin/phpunit -v

--- a/Annotation/Supervisor.php
+++ b/Annotation/Supervisor.php
@@ -12,23 +12,15 @@ use Doctrine\Common\Annotations\Annotation;
  */
 class Supervisor
 {
-    /**
-     * @var integer
-     */
+    /** @var integer */
     public $processes;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $params;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $executor;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $server;
 }

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -2,6 +2,7 @@
 
 namespace MyBuilder\Bundle\SupervisorBundle\Command;
 
+use MyBuilder\Bundle\SupervisorBundle\Exporter\AnnotationSupervisorExporter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -27,12 +28,13 @@ class DumpCommand extends Command implements ContainerAwareInterface
     {
         $commands = $this->getApplication()->all();
 
+        /** @var AnnotationSupervisorExporter $exporter */
         $exporter = $this->getContainer()->get('mybuilder.supervisor_bundle.annotation_supervisor_exporter');
 
         $output->write($exporter->export($commands, $this->parseOptions($input)));
     }
 
-    private function parseOptions(InputInterface $input)
+    private function parseOptions(InputInterface $input): array
     {
         $options = [];
 
@@ -51,13 +53,12 @@ class DumpCommand extends Command implements ContainerAwareInterface
         return $options;
     }
 
-    /**
-     * @throws \LogicException
-     */
+    /** @throws \LogicException */
     protected function getContainer(): ContainerInterface
     {
         if (null === $this->container) {
             $application = $this->getApplication();
+
             if (null === $application) {
                 throw new \LogicException('The container cannot be retrieved as the application instance is not yet set.');
             }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -7,10 +7,17 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('my_builder_supervisor');
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
+            // Symfony 4
+            $treeBuilder = new TreeBuilder('my_builder_supervisor');
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // Symfony 3
+            $treeBuilder = new TreeBuilder();
+            $rootNode = $treeBuilder->root('my_builder_supervisor');
+        }
 
         $rootNode
             ->children()
@@ -18,7 +25,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->variableNode('program')->end()
                         ->scalarNode('executor')->example('php')->end()
-                        ->scalarNode('console')->example('app/console (bin/console)')->end()
+                        ->scalarNode('console')->example('bin/console')->end()
                     ->end()
             ->end();
 

--- a/DependencyInjection/MyBuilderSupervisorExtension.php
+++ b/DependencyInjection/MyBuilderSupervisorExtension.php
@@ -16,7 +16,7 @@ class MyBuilderSupervisorExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
 
-        $exporterConfig = isset($config['exporter']) ? $config['exporter'] : array();
+        $exporterConfig = $config['exporter'] ?? [];
         $container->setParameter('mybuilder.supervisor_bundle.exporter_config', $exporterConfig);
     }
 }

--- a/MyBuilderSupervisorBundle.php
+++ b/MyBuilderSupervisorBundle.php
@@ -4,4 +4,6 @@ namespace MyBuilder\Bundle\SupervisorBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MyBuilderSupervisorBundle extends Bundle {}
+class MyBuilderSupervisorBundle extends Bundle
+{
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/mybuilder/supervisor-bundle.svg?branch=master)](https://travis-ci.org/mybuilder/supervisor-bundle)
 
-A bundle for Symfony 2/3/4 which allows you to use `@Supervisor` annotations to configure how [Supervisor](http://supervisord.org/) runs your console commands.
+A bundle for Symfony 3/4 which allows you to use `@Supervisor` annotations to configure how [Supervisor](http://supervisord.org/) runs your console commands.
 
 ## Installation
 
@@ -16,19 +16,28 @@ $ php composer.phar require mybuilder/supervisor-bundle
 
 ### Enable the bundle
 
-Enable the bundle in the `app/AppKernel.php`:
+Enable the bundle in the `app/AppKernel.php` for Symfony 3:
 
 ``` php
-public function registerBundles() {
-    $bundles = [
+public function registerBundles(): array
+{
+    return [
         new MyBuilder\Bundle\SupervisorBundle\MyBuilderSupervisorBundle(),
     ];
 }
 ```
 
+Enable the bundle in the `config/bundles.php` for Symfony 4:
+
+```php
+return [
+    MyBuilder\Bundle\SupervisorBundle\MyBuilderSupervisorBundle::class => ['all' => true],
+];
+```
+
 ### Configure the bundle
 
-You can add the following to your `config.yml` to define your global export configuration.
+You can add the following to your `config.yml` (Symfony 3) / `packages/my_builder_supervisor.yaml` (Symfony 4) to define your global export configuration.
 
 ```yaml
 my_builder_supervisor:
@@ -41,7 +50,7 @@ my_builder_supervisor:
         executor: php 
         
         # allows you to specify the console that all commands should be passed to
-        console: app/console
+        console: bin/console
 ```
 
 ## Usage
@@ -71,7 +80,7 @@ You should run `app/console supervisor:dump` and review what the Supervisor conf
 If you are happy with this you can write out the configuration to a `conf` file:
 
 ```
-$ app/console supervisor:dump --user=mybuilder --server=web > "/etc/supervisor.d/symfony.conf"
+$ bin/console supervisor:dump --user=mybuilder --server=web > "/etc/supervisor.d/symfony.conf"
 ```
 
 And then reload Supervisor:
@@ -85,7 +94,7 @@ $ kill -SIGHUP $(supervisorctl pid)
 You can choose which environment you want to run the commands in Supervisor under like this:
 
 ```
-$ app/console supervisor:dump --server=web --env=prod
+$ bin/console supervisor:dump --server=web --env=prod
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ class SendQueuedEmailsCommand extends Command {}
 
 ## Exporting the Supervisor configuration
 
-You should run `app/console supervisor:dump` and review what the Supervisor configuration will look like based on the current specified definition.
+You should run `bin/console supervisor:dump` and review what the Supervisor configuration will look like based on the current specified definition.
 If you are happy with this you can write out the configuration to a `conf` file:
 
 ```

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,5 +1,4 @@
 services:
-
     mybuilder.supervisor_bundle.annotation_supervisor_exporter:
         class: MyBuilder\Bundle\SupervisorBundle\Exporter\AnnotationSupervisorExporter
         public: true

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -13,7 +13,7 @@ class DumpCommandTest extends SupervisorTestCase
     private $application;
     private $command;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $kernel = $this->createKernel();
         $kernel->boot();
@@ -26,21 +26,23 @@ class DumpCommandTest extends SupervisorTestCase
         $this->command = $this->application->find('supervisor:dump');
     }
 
-    public function test_dump_export()
+    public function test_dump_export(): void
     {
         $commandTester = new CommandTester($this->command);
-        $commandTester->execute([
-            'command' => $this->command->getName(),
-            '--user' => 'mybuilder',
-            '--server' => 'live'
-        ]);
+        $commandTester->execute(
+            [
+                'command' => $this->command->getName(),
+                '--user' => 'mybuilder',
+                '--server' => 'live',
+            ]
+        );
 
         $expected = <<<OUTPUT
 [program:supervisor_test-command]
 autostart=true
 user=mybuilder
 name=supervisor_test-command
-command=php app/console supervisor:test-command --env=test
+command=php bin/console supervisor:test-command --env=test
 numprocs=1
 
 [program:supervisor_test-command_2]
@@ -48,14 +50,14 @@ process_name=%(program_name)s_%(process_num)02d
 autostart=true
 user=mybuilder
 name=supervisor_test-command_2
-command=php app/console supervisor:test-command --env=test
+command=php bin/console supervisor:test-command --env=test
 numprocs=2
 
 [program:supervisor_test-command_3]
 autostart=true
 user=mybuilder
 name=supervisor_test-command_3
-command=php -d mbstring.func_overload=0 app/console supervisor:test-command --foo --env=test
+command=php -d mbstring.func_overload=0 bin/console supervisor:test-command --foo --env=test
 numprocs=1
 OUTPUT;
         $this->assertEquals($expected, $commandTester->getDisplay());

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -6,24 +6,30 @@ use MyBuilder\Bundle\SupervisorBundle\Command\DumpCommand;
 use MyBuilder\Bundle\SupervisorBundle\Tests\Fixtures\Command\TestCommand;
 use MyBuilder\Bundle\SupervisorBundle\Tests\SupervisorTestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class DumpCommandTest extends SupervisorTestCase
 {
-    private $application;
+    /** @var Command */
     private $command;
 
     protected function setUp(): void
     {
-        $kernel = $this->createKernel();
+        $kernel = self::createKernel();
         $kernel->boot();
 
-        $this->application = new Application($kernel);
+        $application = new Application($kernel);
 
-        $this->application->add(new DumpCommand());
-        $this->application->add(new TestCommand());
+        $application->add(new DumpCommand());
+        $application->add(new TestCommand());
 
-        $this->command = $this->application->find('supervisor:dump');
+        $this->command = $application->find('supervisor:dump');
+    }
+
+    protected function tearDown(): void
+    {
+        self::ensureKernelShutdown();
     }
 
     public function test_dump_export(): void

--- a/Tests/DependencyInjection/MyBuilderSupervisorExtensionTest.php
+++ b/Tests/DependencyInjection/MyBuilderSupervisorExtensionTest.php
@@ -5,7 +5,6 @@ namespace MyBuilder\Bundle\SupervisorBundle\Tests\DependencyInjection;
 use MyBuilder\Bundle\SupervisorBundle\DependencyInjection\MyBuilderSupervisorExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Yaml\Yaml;
 
@@ -24,12 +23,9 @@ class MyBuilderSupervisorExtensionTest extends TestCase
     }
 
     /**
-     * @param array $expected
-     * @param string $file yaml config file to load
-     *
      * @dataProvider providerTestConfig
      */
-    public function test_config(array $expected, $file): void
+    public function test_config(array $expected, string $file): void
     {
         $this->loader->load($this->getConfig($file), $this->container);
 

--- a/Tests/DependencyInjection/MyBuilderSupervisorExtensionTest.php
+++ b/Tests/DependencyInjection/MyBuilderSupervisorExtensionTest.php
@@ -3,77 +3,71 @@
 namespace MyBuilder\Bundle\SupervisorBundle\Tests\DependencyInjection;
 
 use MyBuilder\Bundle\SupervisorBundle\DependencyInjection\MyBuilderSupervisorExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Yaml\Yaml;
 
-class MyBuilderSupervisorExtensionTest extends \PHPUnit_Framework_TestCase
+class MyBuilderSupervisorExtensionTest extends TestCase
 {
-    /**
-     * @var MyBuilderSupervisorExtension
-     */
+    /** @var MyBuilderSupervisorExtension */
     private $loader;
 
-    /**
-     * @var ContainerBuilder
-     */
+    /** @var ContainerBuilder */
     private $container;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->container = new ContainerBuilder();
         $this->loader = new MyBuilderSupervisorExtension();
     }
 
     /**
-     * @param array  $expected
+     * @param array $expected
      * @param string $file yaml config file to load
      *
      * @dataProvider providerTestConfig
      */
-    public function testConfig(array $expected, $file)
+    public function test_config(array $expected, $file): void
     {
         $this->loader->load($this->getConfig($file), $this->container);
 
         $this->assertEquals($expected, $this->container->getParameter('mybuilder.supervisor_bundle.exporter_config'));
     }
 
-    public function providerTestConfig()
+    public function providerTestConfig(): array
     {
         return [
             [
                 [],
-                'empty.yml'
+                'empty.yml',
             ],
             [
                 [
                     'program' => [
-                        'autostart' => 'true'
+                        'autostart' => 'true',
                     ],
                     'executor' => 'php',
-                    'console' => 'app/console',
+                    'console' => 'bin/console',
                 ],
-                'full.yml'
+                'full.yml',
             ],
         ];
     }
 
     /**
      * Load the specified yaml config file.
-     *
-     * @param string $fileName
-     *
-     * @return array
      */
-    private function getConfig($fileName)
+    private function getConfig(string $fileName): array
     {
         $locator = new FileLocator(__DIR__ . '/config');
         $file = $locator->locate($fileName, null, true);
 
         $config = Yaml::parse(file_get_contents($file));
+
         if (null === $config) {
-            return array();
+            return [];
         }
 
         return $config;

--- a/Tests/DependencyInjection/config/full.yml
+++ b/Tests/DependencyInjection/config/full.yml
@@ -3,4 +3,4 @@ my_builder_supervisor:
         program:
             autostart: 'true'
         executor: php
-        console: app/console
+        console: bin/console

--- a/Tests/Fixtures/app/AppKernel.php
+++ b/Tests/Fixtures/app/AppKernel.php
@@ -12,12 +12,10 @@ class AppKernel extends Kernel
 {
     public function registerBundles()
     {
-        $bundles = [
+        return [
             new FrameworkBundle(),
             new MyBuilderSupervisorBundle(),
         ];
-
-        return $bundles;
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)

--- a/Tests/Fixtures/app/AppKernel.php
+++ b/Tests/Fixtures/app/AppKernel.php
@@ -12,10 +12,10 @@ class AppKernel extends Kernel
 {
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
             new FrameworkBundle(),
             new MyBuilderSupervisorBundle(),
-        );
+        ];
 
         return $bundles;
     }

--- a/Tests/Fixtures/app/config/test.yml
+++ b/Tests/Fixtures/app/config/test.yml
@@ -6,4 +6,4 @@ my_builder_supervisor:
         program:
             autostart: 'true'
         executor: php
-        console: app/console
+        console: bin/console

--- a/Tests/SupervisorTestCase.php
+++ b/Tests/SupervisorTestCase.php
@@ -8,7 +8,7 @@ class SupervisorTestCase extends WebTestCase
 {
     protected static function getKernelClass()
     {
-        require_once __DIR__.'/Fixtures/app/AppKernel.php';
+        require_once __DIR__ . '/Fixtures/app/AppKernel.php';
 
         return 'MyBuilder\Bundle\SupervisorBundle\Tests\Fixtures\app\AppKernel';
     }

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 
 // Composer
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
-    $loader = require_once __DIR__ . '/../vendor/autoload.php';
+    $loader = require __DIR__ . '/../vendor/autoload.php';
 
     AnnotationRegistry::registerLoader('class_exists');
 

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -5,8 +5,8 @@ error_reporting(error_reporting() & ~E_USER_DEPRECATED);
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
 // Composer
-if (file_exists(__DIR__.'/../vendor/autoload.php')) {
-    $loader = require_once __DIR__.'/../vendor/autoload.php';
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    $loader = require_once __DIR__ . '/../vendor/autoload.php';
 
     AnnotationRegistry::registerLoader('class_exists');
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,10 @@
 {
   "name": "mybuilder/supervisor-bundle",
-  "description": "Symfony 2/3/4 bundle which allows you to use @Supervisor annotations to configure how Supervisor runs your console commands.",
-  "keywords": ["supervisor", "supervisord"],
+  "description": "Symfony 3/4 bundle which allows you to use @Supervisor annotations to configure how Supervisor runs your console commands.",
+  "keywords": [
+    "supervisor",
+    "supervisord"
+  ],
   "minimum-stability": "stable",
   "license": "MIT",
   "authors": [
@@ -14,10 +17,10 @@
   "require": {
     "francodacosta/supervisord": "~1.0",
     "doctrine/annotations": "~1.0",
-    "symfony/console": "~2.7 || ~3.0 || ~4.0",
-    "symfony/config": "~2.7 || ~3.0 || ~4.0",
-    "symfony/framework-bundle": "~2.7 || ~3.0 || ~4.0",
-    "php": "~7.0"
+    "symfony/console": "~3.0||~4.0",
+    "symfony/config": "~3.0||~4.0",
+    "symfony/framework-bundle": "~3.0||~4.0",
+    "php": ">=7.3"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.0"

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,11 @@
     "symfony/console": "~3.0||~4.0",
     "symfony/config": "~3.0||~4.0",
     "symfony/framework-bundle": "~3.0||~4.0",
+    "symfony/yaml": "~3.0||^4.0",
     "php": ">=7.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.0"
+    "phpunit/phpunit": "~9.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,16 +2,15 @@
 
 <!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit
-        backupGlobals = "false"
-        backupStaticAttributes = "false"
-        colors = "true"
-        convertErrorsToExceptions = "true"
-        convertNoticesToExceptions = "true"
-        convertWarningsToExceptions = "true"
-        processIsolation = "false"
-        stopOnFailure = "true"
-        syntaxCheck = "false"
-        bootstrap = "Tests/bootstrap.php" >
+        backupGlobals="false"
+        backupStaticAttributes="false"
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        processIsolation="false"
+        stopOnFailure="true"
+        bootstrap="Tests/bootstrap.php">
 
     <testsuites>
         <testsuite name="Project Test Suite">


### PR DESCRIPTION
- Add Symfony 4 support
- Add PHP 7.4 support
- Fix deprecation notices for Symfony 3/4
- Fix missing TreeBuilder root node, if supported
- Drop support for old (unsupported) versions of Symfony and PHP
- Tidy up code styling